### PR TITLE
Add compatibility with Django 1.9+

### DIFF
--- a/tower/__init__.py
+++ b/tower/__init__.py
@@ -7,6 +7,7 @@ import re
 
 import django
 from django.conf import settings
+from django.utils import six
 from django.utils.functional import lazy
 from django.utils.translation import (trans_real as django_trans,
                                       ugettext as django_ugettext,
@@ -54,8 +55,9 @@ def ungettext(singular, plural, number, context=None):
         return plural_stripped
     return ret
 
-ugettext_lazy = lazy(ugettext, str)
-ungettext_lazy = lazy(ungettext, str)
+
+ugettext_lazy = lazy(ugettext, six.text_type)
+ungettext_lazy = lazy(ungettext, six.text_type)
 
 
 def add_context(context, message):

--- a/tower/__init__.py
+++ b/tower/__init__.py
@@ -1,5 +1,6 @@
 from past.builtins import basestring
 from builtins import object
+from importlib import import_module
 import copy
 import gettext
 import re
@@ -7,7 +8,6 @@ import re
 import django
 from django.conf import settings
 from django.utils.functional import lazy
-from django.utils.importlib import import_module
 from django.utils.translation import (trans_real as django_trans,
                                       ugettext as django_ugettext,
                                       ungettext as django_nugettext)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-1.4, py27-1.5, py27-1.6, py27-1.7, py36-1.8
+envlist = py27-1.5, py27-1.6, py27-1.7, py36-1.8
 
 [testenv]
 commands =
@@ -11,15 +11,6 @@ deps =
     django-nose==1.4.3
     mock
     future
-
-[testenv:py27-1.4]
-basepython = python2.7
-deps =
-    Django==1.4.20
-    -egit+https://github.com/jbalogh/jingo.git@v0.7.1#egg=jingo
-    babel==1.3
-    {[testenv]deps}
-
 
 [testenv:py27-1.5]
 basepython = python2.7


### PR DESCRIPTION
Note that jingo does not support Django 1.8+, so those tests would fail.  Non-jingo functionality works fine.